### PR TITLE
Feature - Consent Form and Participant Information Sheet

### DIFF
--- a/react-interface/package-lock.json
+++ b/react-interface/package-lock.json
@@ -14314,6 +14314,11 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+    },
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",

--- a/react-interface/package.json
+++ b/react-interface/package.json
@@ -10,14 +10,15 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "concurrently": "^5.3.0",
+    "electron-is-dev": "^1.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",
     "react-scripts": "3.4.3",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
-    "wait-on": "^5.2.0",
-    "electron-is-dev": "^1.2.0"
+    "wait-on": "^5.2.0"
   },
   "devDependencies": {
     "electron": "^10.1.2",

--- a/react-interface/src/App.js
+++ b/react-interface/src/App.js
@@ -18,6 +18,7 @@ import PrePuzzlePage from './components/PrePuzzlePage';
 import PuzzlePage from './components/PuzzlePage';
 import SurveyPage from './components/SurveyPage';
 import ThankYouPage from './components/ThankYouPage';
+import ParticipantInformationSheetPage from './components/ParticipantInformationSheetPage';
 
 // Theme, used for global MUI styling definitions
 const theme = {
@@ -29,6 +30,7 @@ const theme = {
 // Pages, stored dynamically
 const pages = [
   LandingPage, 
+  ParticipantInformationSheetPage,
   ConsentFormPage, 
   TaskSelectionPage, 
   PrePuzzlePage, 

--- a/react-interface/src/components/ConsentFormPage.js
+++ b/react-interface/src/components/ConsentFormPage.js
@@ -1,8 +1,11 @@
 import React from 'react';
 
 // Material UI imports
-import { Paper, Slide, withStyles } from '@material-ui/core';
+import { Checkbox, Divider, FormControlLabel, Paper, Slide, TextField, withStyles } from '@material-ui/core';
 import { Typography, Button } from '@material-ui/core'
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { changeExperimentState } from '../redux/actions/experimentActions';
 
 // JSS Styles for this page
 const styles = theme => ({
@@ -16,9 +19,11 @@ const styles = theme => ({
     content: {
         marginTop: theme.spacing(2),
         padding: '3vh',
+        textAlign: 'left'
     },
     paragraph: {
-        marginBottom: theme.spacing(2)
+        marginLeft: theme.spacing(2),
+        textIndent: theme.spacing(2)
     },
     button: {
         margin: theme.spacing(2),
@@ -31,7 +36,21 @@ class ConsentFormPage extends React.Component {
     constructor(props) {
         super();
         this.state = {
-            transition: false
+            transition: false,
+            checks: [
+                false, // I have read the Participant Information Sheet, and understood the nature of the research and I have had the opportunity to ask questions and have had them answered to my satisfaction 
+                false, // I have read the Participant Information Sheet, and understood the nature of the research. I have had the opportunity to ask questions and have had them answered to my satisfaction. 
+                false, // I agree to take part in this research.
+                false, // I agree to my problem solving performance being recorded. 
+                false, // I agree for my EEG data to be recorded.
+                false, // I understand that my responses will be analysed separately from my information to ensure confidentiality. 
+                false, // I understand that I am free to withdraw my participation at any time, and to withdraw any data traceable up to me one month after participation. 
+                false, // I understand that the data will be used for a research project and potential publications.
+            ],
+            shouldMailFindings: false, // I wish/do not wish to receive a summary of findings, which can be emailed or mailed to me at this address: 
+            email: '',
+            consent: false,
+            participantId: "",
         }
     }
 
@@ -41,6 +60,43 @@ class ConsentFormPage extends React.Component {
 
     componentWillUnmount() {
         this.setState({ transition: false });
+    }
+
+    handleCheck(index) {
+        var newChecks = this.state.checks;
+        newChecks[index] = !this.state.checks[index]
+        this.setState({ checks: newChecks, consent: false })
+
+        console.log(this.state)
+    }
+
+    handleShouldMailFindings() {
+        this.setState({ shouldMailFindings: !this.state.shouldMailFindings })
+        this.setState({email: ''})
+    }
+
+    canConsent() {
+        // If every check is accepted, the user can consent
+        for (var i = 0; i < this.state.checks.length; i++) {
+            if (!this.state.checks[i]) {
+                return false;
+            }
+        }
+
+        // Check participant ID is valid - TO BE IMPLEMENTED PROPERLY
+        if (this.state.participantId === "") {
+            return false;
+        }
+
+        return true;
+    }
+
+    handleEmail(event){
+        this.setState({email: event.target.value})
+    }
+
+    handleParticipantId(event) {
+        this.setState({ participantId: event.target.value })
     }
 
     render() {
@@ -57,27 +113,68 @@ class ConsentFormPage extends React.Component {
                         Consent Form
                     </Typography>
                     <Typography variant="h5" align="left">
-                        First, we require you to read this consent form thoroughly. 
+                        We require you to read this consent form thoroughly.
                     </Typography>
                     <Typography variant="h5" align="left">
-                        Once you have read the form, click 'I consent'.
+                        Once you have read the form, click 'I consent'. If you agree with everything below, you may proceed.
                     </Typography>
                     <Paper elevation={3} className={classes.content}>
-                        <Typography className={classes.paragraph} align="left">
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis dui elementum, commodo nunc sit amet, egestas risus.
-                            Integer sed lorem justo. Integer eget suscipit odio. Nam eget odio id metus auctor dignissim sit amet quis sem.
-                            Pellentesque at mollis ligula. Nam a libero a nisi laoreet faucibus. Phasellus id sem ut metus pharetra imperdiet quis a ligula.
-                            Integer facilisis nisi in nulla scelerisque, volutpat ultricies justo volutpat. Phasellus in erat metus.
-                            Quisque pulvinar tortor sit amet massa euismod, id congue tellus ultricies. Nunc sit amet ex mauris.
-                            Mauris tempus nunc a congue feugiat.
+                        <Typography variant="h6" align="left" style={{ marginBottom: 20 }}>
+                            Consent Form
                         </Typography>
-                        <Typography className={classes.paragraph} align="left">
-                            Donec semper nunc sed felis condimentum imperdiet. Ut luctus fermentum nulla, et rhoncus nisl ultrices vitae.
-                            Vestibulum in sagittis ipsum. Phasellus tellus nulla, hendrerit vitae purus vel, euismod porta justo.
-                            Proin efficitur fermentum ultricies. Vivamus ut tellus sit amet massa pellentesque porttitor in ut tortor.
-                            Fusce mauris velit, placerat quis lacus vel, sollicitudin auctor ex. Pellentesque dignissim et nulla id euismod.
-                            Duis bibendum dolor ut tortor congue tempus. Mauris vitae nibh turpis.
-                        </Typography>
+
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[0]} onChange={() => { this.handleCheck(0) }} className={classes.paragraph} />}
+                            label="I have read the Participant Information Sheet, and understood the nature of the research.
+                            I have also had the opportunity to ask questions and have had them answered to my satisfaction"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[1]} onChange={() => { this.handleCheck(1) }} className={classes.paragraph} />}
+                            label="I have read the Participant Information Sheet, and understood the nature of the research.
+                            I have also had the opportunity to ask questions and have had them answered to my satisfaction"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[2]} onChange={() => { this.handleCheck(2) }} className={classes.paragraph} />}
+                            label="I agree to take part in this research"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[3]} onChange={() => { this.handleCheck(3) }} className={classes.paragraph} />}
+                            label="I agree to my problem solving performance being recorded"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[4]} onChange={() => { this.handleCheck(4) }} className={classes.paragraph} />}
+                            label="I agree for my EEG data to be recorded"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[5]} onChange={() => { this.handleCheck(5) }} className={classes.paragraph} />}
+                            label="I understand that my responses will be analysed separately from my information to ensure confidentiality"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[6]} onChange={() => { this.handleCheck(6) }} className={classes.paragraph} />}
+                            label="I understand that I am free to withdraw my participation at any time, and to withdraw any data traceable up to me one month after participation"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.checks[7]} onChange={() => { this.handleCheck(7) }} className={classes.paragraph} />}
+                            label=" I understand that the data will be used for a research project and potential publications"
+                        /><Divider style={{ marginBottom: 20 }} />
+                        <FormControlLabel
+                            control={<Checkbox checked={this.state.shouldMailFindings} onChange={() => { this.handleShouldMailFindings() }} className={classes.paragraph} />}
+                            label="(OPTIONAL) I wish/do not wish to receive a summary of findings."
+                        />
+
+                        {
+                            this.state.shouldMailFindings &&
+                            <div>
+                                <Typography className={classes.paragraph} style={{ textIndent: 0 }} align="left">
+                                    My email address (for receiving findings) is this:
+                                </Typography>
+                                <TextField className={classes.paragraph} style={{ textIndent: 0, width: 500 }} onChange={this.handleEmail.bind(this)} variant="outlined" label="Email"/>
+                            </div>
+                        }
+                        <br />
+                        <Divider style={{ marginBottom: 20 }} />
+                        <Typography>Please enter your participant ID before continuing</Typography>
+                        <TextField label="Participant ID" onChange={this.handleParticipantId.bind(this)}></TextField>
                     </Paper>
                     <Button className={classes.button}
                         variant="contained"
@@ -88,8 +185,12 @@ class ConsentFormPage extends React.Component {
                     <Button className={classes.button}
                         variant="contained"
                         color="secondary"
-                        onClick={this.props.nextPage}>
-                        I consent
+                        onClick={() => {
+                            this.props.changeExperimentState({participantId: this.state.participantId, email: this.state.email})
+                            this.props.nextPage()
+                        }}
+                        disabled={!this.canConsent()}>
+                        Next
                     </Button>
                 </div>
             </Slide>
@@ -97,5 +198,13 @@ class ConsentFormPage extends React.Component {
     }
 }
 
+const mapStateToProps = state => ({
+    experiment: state.experiment,
+})
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+    changeExperimentState: changeExperimentState,
+}, dispatch)
+
 // Export - Attaches Redux state, and styling
-export default withStyles(styles)(ConsentFormPage);
+export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(ConsentFormPage));

--- a/react-interface/src/components/ParticipantInformationSheetPage.js
+++ b/react-interface/src/components/ParticipantInformationSheetPage.js
@@ -1,0 +1,138 @@
+import React from 'react';
+
+// Material UI imports
+import { Paper, Slide, withStyles } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core'
+
+// JSS Styles for this page
+const styles = theme => ({
+    root: {
+        padding: '5vh',
+        paddingTop: '10vh',
+        textAlign: 'center',
+        maxWidth: '800px',
+        margin: 'auto'
+    },
+    content: {
+        marginTop: theme.spacing(2),
+        padding: '3vh',
+    },
+    paragraph: {
+        marginBottom: theme.spacing(5),
+        marginLeft: theme.spacing(2),
+        textIndent: theme.spacing(2)
+    },
+    button: {
+        margin: theme.spacing(2),
+        fontSize: '20px'
+    }
+})
+
+// React class component definition
+class ParticipantInformationSheetPage extends React.Component {
+    constructor(props) {
+        super();
+        this.state = {
+            transition: false
+        }
+    }
+
+    componentDidMount() {
+        this.setState({ transition: true });
+    }
+
+    componentWillUnmount() {
+        this.setState({ transition: false });
+    }
+
+    render() {
+        const classes = this.props.classes;
+
+        return (
+            <Slide direction={this.props.transitionDirection} in={this.state.transition}
+                style={
+                    { transformOrigin: '0 0 0' }}
+                {...(this.state.transition ? { timeout: 1000 } : {})}
+            >
+                <div className={classes.root}>
+                    <Typography variant="h2">
+                        Participant Information Sheet
+                    </Typography>
+                    <Typography variant="h5" align="left">
+                        Please read through this information sheet.
+                    </Typography>
+                    <Typography variant="h5" align="left">
+                        Once you have read the sheet, click 'Next'.
+                    </Typography>
+                    <Paper elevation={3} className={classes.content}>
+                        <Typography variant="h6" align="left">Introduction</Typography>
+                        <Typography className={classes.paragraph} align="left">
+                            We, Callum Cory, Kelvin Ngor, Terence Qu, Ryan Tan and William Li, are students in the COMPSCI705/SOFTENG702 class. Our supervisor is Dr. Danielle Lottridge.
+                        </Typography>
+
+                        <Typography variant="h6" align="left">This Project</Typography>
+                        <Typography className={classes.paragraph} style={{textIndent: 0}} align="left">
+                            - <b>Rationale:</b> We want to better understand the relationship between meditation and problem solving tasks. <br/>
+                            - <b>Aims:</b> The results of this project will be used to better understand the physiological effects of meditation of problem solving tasks. <br/>
+                            - <b>Project Duration:</b> We will work on this project until the end of semester 2020. <br/>
+                            - <b>Benefits:</b> The final outcome of this project will be a new knowledge on the relationship between meditation and problem solving. 
+                            This research will allow us to understand how meditation affects people's ability to problem solve. <br/>
+                            - <b>Risks:</b> Participation in this research is optinal, and responses will be kept confidential in order to minimise your risks as a participant. <br/>
+                        </Typography>
+
+                        <Typography variant="h6" align="left">Invation to participate</Typography>
+                        <Typography className={classes.paragraph} align="left">
+                            Voluntary participantion: Your participation is vountary and you may decline this invitation without penalty.
+                        </Typography>
+
+                        <Typography variant="h6" align="left">Project Procedures:</Typography>
+                        <Typography className={classes.paragraph} align="left">
+                            If you choose to participate, you will be asked to attend two sessions at the University of Auckland downtown campus. 
+                            During the sessions, you will be asked to wear a Neurosky Mindwave headset device and to complete several problem solving questions. 
+                            The headset fits over the head with a clip to the earlobe. In one session, you will use your cellphone for 15 minutes, and in 
+                            another session you will be asked to meditation for 15 minutes. Upon completion of these sessions, you will be asked to complete 
+                            some problem solving questions. You will also be asked to fill out a questionnaire on how you found the tasks. The expected time 
+                            commitment is 60 minutes or less. You can choose to stop the sessions at any time without penalty. 
+                        </Typography>
+
+                        <Typography variant="h6" align="left">Data storage, retention, destruction and future use</Typography>
+                        <Typography className={classes.paragraph} align="left">
+                            How: We will collect recordings of EEG, performance on the problem solving tasks, 
+                            and responses to a questionnaire. 
+                        </Typography>
+
+                        <Typography variant="h6" align="left">Right to withdraw from participation</Typography>
+                        <Typography className={classes.paragraph} align="left">
+                            You can withdraw from the session at any time without having to provide a reason.
+                        </Typography>
+
+                        <Typography variant="h6" align="left">Confidentiality</Typography>
+                        <Typography className={classes.paragraph} align="left">
+                            The preservation of confidentiality is paramount. The information you share through this session will remain confidential to only the involved researchers.
+                            Your responses will be analysed separately from your contact information to ensure confidentialty. 
+                            The information you provide will be reported in project reports written individually by each researcher, 
+                            and may be published in an academic research conference and/or journal. This report and publication(s) will not identify you as its source. 
+                            A copy of the research findings will be made available to you, if you wish. You can also contact any of the researchers 
+                            listed below if you would like to obtain a copy of the findings. 
+                        </Typography>
+                    </Paper>
+                    <Button className={classes.button}
+                        variant="contained"
+                        color="primary"
+                        onClick={this.props.previousPage}>
+                        Back
+                    </Button>
+                    <Button className={classes.button}
+                        variant="contained"
+                        color="secondary"
+                        onClick={this.props.nextPage}>
+                        Next
+                    </Button>
+                </div>
+            </Slide>
+        );
+    }
+}
+
+// Export - Attaches Redux state, and styling
+export default withStyles(styles)(ParticipantInformationSheetPage);

--- a/react-interface/src/components/TaskSelectionPage.js
+++ b/react-interface/src/components/TaskSelectionPage.js
@@ -66,14 +66,6 @@ class TaskSelectionPage extends React.Component {
                     <Button
                         className={classes.button}
                         variant="contained"
-                        color="primary"
-                        onClick={this.props.previousPage}
-                    >
-                        Go Back
-                    </Button>
-                    <Button
-                        className={classes.button}
-                        variant="contained"
                         color="secondary"
                         onClick={this.pressAlpha.bind(this)}
                     >

--- a/react-interface/src/redux/reducers/experimentReducers.js
+++ b/react-interface/src/redux/reducers/experimentReducers.js
@@ -2,6 +2,8 @@ import { CHANGE_EXPERIMENT_STATE } from './../actions/experimentActions';
 
 // The initial state of the experiment state
 const initialState = {
+    participantId: '',
+    email: '',
     // Group - 'control' or 'meditation'
     group: '',
 }

--- a/react-interface/src/redux/store.js
+++ b/react-interface/src/redux/store.js
@@ -1,5 +1,7 @@
+import { composeWithDevTools } from 'redux-devtools-extension';
+
 import { applyMiddleware, createStore } from "redux";
 import thunk from 'redux-thunk';
 import rootReducer from "./reducers";
 
-export default createStore(rootReducer, applyMiddleware(thunk));
+export default createStore(rootReducer, composeWithDevTools(applyMiddleware(thunk)));


### PR DESCRIPTION
This commit adds:
- a Participant Information Sheet Page which displays PIS to the user.
- Consent Form page content - users must agree to each item in the consent form before proceeding - the page also allows users to sign up for mailing
- All necessary consent form information is stored in Redux state